### PR TITLE
add authorize!/3 and verify_authorized/2

### DIFF
--- a/lib/authy/errors.ex
+++ b/lib/authy/errors.ex
@@ -1,0 +1,7 @@
+defmodule Authy.NotAuthorizedError do
+  defexception [:message]
+end
+
+defimpl Plug.Exception, for: Authy.NotAuthorizedError do
+  def status(_exception), do: 403 # Forbidden
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,14 +15,15 @@ defmodule Authy.Mixfile do
   end
 
   def application, do: []
-  
-  defp deps do 
-    [{:ex_doc, ">= 0.0.0", only: :dev}]
+
+  defp deps do
+    [{:plug, "~> 1.0"},
+     {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 
   defp description do
     """
-    Authy is a simple authorization library for Elixir and Phoenix apps. 
+    Authy is a simple authorization library for Elixir and Phoenix apps.
     It imposes some naming conventions so that policy modules can be easily
     located and queried at runtime depending on the context of the authorization.
     It was inspired by the behavior and conventions of Ruby's Pundit gem.

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
 %{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]}}

--- a/test/authy/controller_test.exs
+++ b/test/authy/controller_test.exs
@@ -1,0 +1,61 @@
+defmodule Policy.HelpersTest do
+  use ExUnit.Case
+
+  defmodule MockStruct do
+    defstruct permit: false
+  end
+
+  defmodule MockStruct.Policy do
+    def can?(_user, :test, model), do: model.permit
+  end
+
+  setup do
+    conn = Plug.Test.conn(:get, "/") |> Plug.Conn.assign(:action, :test)
+
+    {:ok, conn: conn}
+  end
+
+  test "authorizing a nonpermitted action raises an exception", %{conn: conn} do
+    assert_raise Authy.NotAuthorizedError, fn ->
+      Authy.Controller.authorize!(conn, %MockStruct{permit: false})
+    end
+  end
+
+  test "authorizing a permitted action does not raise an exception", %{conn: conn} do
+    try do
+      Authy.Controller.authorize!(conn, %MockStruct{permit: true})
+    rescue _e ->
+      flunk "exception raised"
+    end
+  end
+
+  test "failing to authorize after verifying it is authorized is run raises an exception", %{conn: conn} do
+    assert_raise Authy.NotAuthorizedError, fn ->
+      conn
+      |> Authy.Controller.verify_authorized
+      |> Plug.Conn.send_resp(200, "Hello, World!")
+    end
+  end
+
+  test "authorizing a permitted action after verifying it is authorized does not raise an exception", %{conn: conn} do
+    try do
+      conn
+      |> Authy.Controller.verify_authorized
+      |> Authy.Controller.authorize!(%MockStruct{permit: true})
+      |> Plug.Conn.send_resp(200, "Hello, World!")
+    rescue _e ->
+      flunk "exception raised"
+    end
+  end
+
+  test "marking authorized after verifying it is authorized does not raise an exception", %{conn: conn} do
+    try do
+      conn
+      |> Authy.Controller.verify_authorized
+      |> Authy.Controller.mark_authorized
+      |> Plug.Conn.send_resp(200, "Hello, World!")
+    rescue _e ->
+      flunk "exception raised"
+    end
+  end
+end

--- a/test/authy_test.exs
+++ b/test/authy_test.exs
@@ -24,10 +24,10 @@ defmodule AuthyTest do
       def scope(_user, :index, _opts), do: :all_posts_scope
       def scope(user, _action, _opts) do
         case user do
-          %{role: :admin} 
+          %{role: :admin}
             -> :admin_posts_scope
           _
-            -> :guest_posts_scope  
+            -> :guest_posts_scope
         end
       end
     end
@@ -112,91 +112,91 @@ defmodule AuthyTest do
     params = %{post: post}
 
     # Test index action - everyone is authorized! So just test the scope
-    conn = %{assigns: %{current_user: nil}, private: %{phoenix_action: :index}}
+    conn = %Plug.Conn{assigns: %{current_user: nil}, private: %{phoenix_action: :index}}
     assert PostController.index(conn, params) == :all_posts_scope
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :index}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :index}}
     assert PostController.index(conn, params) == :all_posts_scope
 
-    conn = %{assigns: %{current_user: admin}, private: %{phoenix_action: :index}}
+    conn = %Plug.Conn{assigns: %{current_user: admin}, private: %{phoenix_action: :index}}
     assert PostController.index(conn, params) == :all_posts_scope
 
     # Test edit action
-    conn = %{assigns: %{current_user: nil}, private: %{phoenix_action: :edit}}
+    conn = %Plug.Conn{assigns: %{current_user: nil}, private: %{phoenix_action: :edit}}
     assert PostController.edit(conn, params) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :edit}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :edit}}
     assert PostController.edit(conn, params) == :guest_posts_scope
 
-    conn = %{assigns: %{current_user: other}, private: %{phoenix_action: :edit}}
+    conn = %Plug.Conn{assigns: %{current_user: other}, private: %{phoenix_action: :edit}}
     assert PostController.edit(conn, params) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: admin}, private: %{phoenix_action: :edit}}
+    conn = %Plug.Conn{assigns: %{current_user: admin}, private: %{phoenix_action: :edit}}
     assert PostController.edit(conn, params) == :admin_posts_scope
 
     # Test show action
-    conn = %{assigns: %{current_user: nil}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: nil}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, params) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, params) == :guest_posts_scope
 
-    conn = %{assigns: %{current_user: other}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: other}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, params) == :guest_posts_scope
 
-    conn = %{assigns: %{current_user: admin}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: admin}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, params) == :admin_posts_scope
 
     # Test showing a nil post (not found)
-    conn = %{assigns: %{current_user: nil}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: nil}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
     assert PostController.show_nils_unauthorized(conn, %{post: nil}) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
     assert PostController.show_nils_not_found(conn, %{post: nil}) == {:error, :not_found}
 
-    conn = %{assigns: %{current_user: other}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: other}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: admin}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: admin}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :unauthorized}
 
     Application.put_env(:authy, :nils, :not_found)
 
-    conn = %{assigns: %{current_user: nil}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: nil}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :not_found}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :not_found}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
     assert PostController.show_nils_unauthorized(conn, %{post: nil}) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :show}}
     assert PostController.show_nils_not_found(conn, %{post: nil}) == {:error, :not_found}
 
-    conn = %{assigns: %{current_user: other}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: other}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :not_found}
 
-    conn = %{assigns: %{current_user: admin}, private: %{phoenix_action: :show}}
+    conn = %Plug.Conn{assigns: %{current_user: admin}, private: %{phoenix_action: :show}}
     assert PostController.show(conn, %{post: nil}) == {:error, :not_found}
 
     # Test delete action
-    conn = %{assigns: %{current_user: nil}, private: %{phoenix_action: :delete}}
+    conn = %Plug.Conn{assigns: %{current_user: nil}, private: %{phoenix_action: :delete}}
     assert PostController.delete(conn, params) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: guest}, private: %{phoenix_action: :delete}}
+    conn = %Plug.Conn{assigns: %{current_user: guest}, private: %{phoenix_action: :delete}}
     assert PostController.delete(conn, params) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: other}, private: %{phoenix_action: :delete}}
+    conn = %Plug.Conn{assigns: %{current_user: other}, private: %{phoenix_action: :delete}}
     assert PostController.delete(conn, params) == {:error, :unauthorized}
 
-    conn = %{assigns: %{current_user: admin}, private: %{phoenix_action: :delete}}
+    conn = %Plug.Conn{assigns: %{current_user: admin}, private: %{phoenix_action: :delete}}
     assert PostController.delete(conn, params) == :admin_posts_scope
   end
 end


### PR DESCRIPTION
I added the bang method and my plug and moved `mark_authorized` up into the public API.  There are doc comments for everything, but I still need to go back and update the README to cover the new cases.

I had to add `plug` as a dependency to get the exception working as intended, and since I had it I went ahead and rewrote `mark_authorized` (and some test stuff) to use it.  I feel pretty okay about it as a dependency, given how tightly tied we are to `conn`, but I'm not 100% certain how to do the versioning to not screw up projects that include this.  Need to do some reading and see how other projects deal with that.

Also, I remembered why I originally used a 403 Forbidden instead of a 401 Unauthorized.  [The spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2) technically specifies that a 401 MUST include a `WWW-Authenticate` header specifying how the client should retry the request.  That's ignored more often than not in the real world, but still...  I'm okay if we decide to switch that later (or allow the user to configure it), but I suspect 403 is probably a better default for most apps.